### PR TITLE
fixed possible race condition inside simple_action_state

### DIFF
--- a/smach_ros/src/smach_ros/simple_action_state.py
+++ b/smach_ros/src/smach_ros/simple_action_state.py
@@ -390,6 +390,10 @@ class SimpleActionState(State):
         self._status = SimpleActionState.INACTIVE
         self._done_cond.release()
 
+        if self.preempt_requested():
+            outcome = 'preempted'
+            self.service_preempt()
+
         return outcome
 
     ### Action client callbacks


### PR DESCRIPTION
a race condition could happen if the `simple_action_state` gets preempted from the smach side after the active action returns and before the state execution is finished.